### PR TITLE
Fix no jurisdiction taxes

### DIFF
--- a/src/mutations/createTaxRate.js
+++ b/src/mutations/createTaxRate.js
@@ -26,7 +26,7 @@ export default async function createTaxRate(context, input) {
 
   const taxRate = {
     _id: Random.id(),
-    country: country === "" ? null : country,
+    country,
     postal,
     rate,
     region,

--- a/src/mutations/createTaxRate.js
+++ b/src/mutations/createTaxRate.js
@@ -26,7 +26,7 @@ export default async function createTaxRate(context, input) {
 
   const taxRate = {
     _id: Random.id(),
-    country,
+    country: country === "" ? null : country,
     postal,
     rate,
     region,

--- a/src/util/calculateOrderTaxes.js
+++ b/src/util/calculateOrderTaxes.js
@@ -28,6 +28,10 @@ async function getTaxesForShop(collections, order) {
         postal: null,
         region: null,
         country: shippingAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: null
       }]
     });
   }
@@ -45,6 +49,10 @@ async function getTaxesForShop(collections, order) {
         postal: null,
         region: null,
         country: originAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: null
       }]
     });
   }


### PR DESCRIPTION
Resolves #3
Impact: **critical**
Type: **bugfix**

## Issue
Taxes for "any jurisdiction" currently don't get applied. This is because the "Country" dropdown returns an empty string instead of a `null` value, causing an empty string to be saved in the database for `country` instead of `null`. Also, the `getTaxesForShop` function doesn't check for `country: null`.

## Solution
Make the `getTaxesForShop` function check for `country: null` in the `$or` selector. Also, make `createTaxRate` insert a `null` value for `country` in case an empty string is passed.

## Breaking changes
Passing an empty string for `country` to `createTaxRate` will save a `null` value instead of an empty string in the database.

## Testing
1. Create a tax rate for "any jurisdiction".
2. On the storefront, use this tax rate on a taxable product.
3. See the tax rate getting applied.