### PR TITLE
fix: pass tax rate without dividing by 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@reactioncommerce/api-utils": "^1.9.0",
-    "@reactioncommerce/random": "^1.0.2",
+    "@reactioncommerce/api-utils": "file:../api-utils",
+    "@reactioncommerce/random": "file:../random",
     "@reactioncommerce/reaction-error": "^1.0.1",
     "simpl-schema": "^1.5.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@reactioncommerce/babel-remove-es-create-require": "~1.0.0",
-    "@reactioncommerce/data-factory": "~1.0.1",
-    "@reactioncommerce/eslint-config": "~2.1.0",
+    "@reactioncommerce/babel-remove-es-create-require": "file:../babel-remove-es-create-require",
+    "@reactioncommerce/data-factory": "file:../data-factory",
+    "@reactioncommerce/eslint-config": "file:../eslint-config",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",

--- a/src/util/calculateOrderTaxes.js
+++ b/src/util/calculateOrderTaxes.js
@@ -59,7 +59,6 @@ async function getTaxesForShop(collections, order) {
   // Also add a name. Someday should allow a shop operator to enter the name.
   return taxDocs.map((doc) => ({
     ...doc,
-    rate: doc.rate / 100,
     name: `${doc.postal || ""} ${doc.region || ""} ${doc.country || ""}`.trim().replace(/\s\s+/g, " ")
   }));
 }


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #2 
Impact: **breaking**
Type: **bugfix**

## Issue
In` reaction-admin`, when you add a tax rate, the form tells you to enter the rate as a decimal. For example, 0.05 equals to a 5% tax.

However, when you create a tax rate following this rule and shop for products using this tax rate on the storefront, the tax calculation isn't actually `price * taxRate` (which it should be), but rather `price * taxRate / 100` (which would only be correct if our tax rate was a percentage to start with, i.e. 5 and not 0.05).

## Solution
Don't divide the tax rate by 100 upon returning it from `getTaxesForShop`.

## Breaking changes
Any tax rates that don't follow the guidance given on the `reaction-admin` new tax rate form (i.e. tax rates stored as integer percentages and not decimals) won't be valid anymore. A stored value of 5 for a tax rate will actually set a tax rate of 500%. When updating, it's important to review tax rates and make sure they're all decimals.


## Testing
1. Create a tax rate following the instructions in `reaction-admin`, for example with a rate of 0.05 (meaning 5%).
2. On the storefront, add a taxable product to the cart and make sure that a 5% tax is applied.
